### PR TITLE
Added ability to customize button text for each social network

### DIFF
--- a/client/views/facebook/facebook.html
+++ b/client/views/facebook/facebook.html
@@ -1,6 +1,6 @@
 <template name="shareit_facebook">
   <a href="#" target="_blank" class="{{classes}}{{#if applyColors}} shareit-facebook-colors{{/if}} fb-share">
     <i class="fa fa-facebook{{faClass}} {{faSize}}"></i>
-    {{#if showText}} Share on Facebook{{/if}}
+    {{#if showText}} {{buttonText.facebook}}{{/if}}
   </a>
 </template>

--- a/client/views/googleplus/googleplus.html
+++ b/client/views/googleplus/googleplus.html
@@ -1,6 +1,6 @@
 <template name="shareit_googleplus">
 <a class="{{classes}}{{#if applyColors}} shareit-google-colors{{/if}} googleplus-share" href="https://plus.google.com/share?url=#{url}"
     onclick="javascript:window.open(this.href,'', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600');return false;">
-    <i class="fa fa-google-plus{{faClass}} {{faSize}}"></i>{{#if showText}} Share on Google+{{/if}}
+    <i class="fa fa-google-plus{{faClass}} {{faSize}}"></i>{{#if showText}} {{buttonText.googleplus}}{{/if}}
 </a>
 </template>

--- a/client/views/pinterest/pinterest.html
+++ b/client/views/pinterest/pinterest.html
@@ -1,5 +1,5 @@
 <template name="shareit_pinterest">
   <a class="{{classes}}{{#if applyColors}} shareit-pinterest-colors{{/if}} pinterest-share" href="https://www.pinterest.com/pin/create/button/?url={{url}}&media={{media}}&description={{description}}">
-    <i class="fa fa-pinterest{{faClass}} {{faSize}}"></i>{{#if showText}} Share on Pinterest{{/if}}
+    <i class="fa fa-pinterest{{faClass}} {{faSize}}"></i>{{#if showText}} {{buttonText.pinterest}}{{/if}}
   </a>
 </template>

--- a/client/views/twitter/twitter.html
+++ b/client/views/twitter/twitter.html
@@ -1,5 +1,5 @@
 <template name="shareit_twitter">
   <a href="https://twitter.com/intent/tweet?url={{url}}&text={{text}}" class="{{classes}}{{#if applyColors}} shareit-twitter-colors{{/if}} tw-share">
-    <i class="fa fa-twitter{{faClass}} {{faSize}}"></i>{{#if showText}} Share on Twitter{{/if}}
+    <i class="fa fa-twitter{{faClass}} {{faSize}}"></i>{{#if showText}} {{buttonText.twitter}}{{/if}}
   </a>
 </template>

--- a/shareit.coffee
+++ b/shareit.coffee
@@ -17,14 +17,19 @@ ShareIt =
         'appId': null
         'version': 'v2.3'
         'description': ''
+        'buttonText': 'Share on Facebook'
       twitter:
         'description': ''
+        'buttonText': 'Share on Twitter'
       googleplus:
         'description': ''
+        'buttonText': 'Share on Google+'
       pinterest:
         'description': ''
+        'buttonText': 'Share on Pinterest'
       instagram:
         'description': ''
+        'buttonText': 'Share on Instagram'
     siteOrder: []
     classes: "large btn"
     iconOnly: false
@@ -41,6 +46,12 @@ ShareIt =
     applyColors: -> ShareIt.settings.applyColors
     faSize: -> ShareIt.settings.faSize
     faClass: -> ShareIt.settings.faClass and "-#{ShareIt.settings.faClass}" or ''
+    buttonText: ->
+      facebook: ShareIt.settings.sites.facebook.buttonText
+      twitter: ShareIt.settings.sites.twitter.buttonText
+      googleplus: ShareIt.settings.sites.googleplus.buttonText
+      pinterest: ShareIt.settings.sites.pinterest.buttonText
+      instagram: ShareIt.settings.sites.instagram.buttonText
 
   init: (params) ->
     @configure params if params?


### PR DESCRIPTION
Customize by setting the 'buttonText' property for each network in the
ShareIt.init() function.

Created helper (buttonText) with properties for each network (eg: buttonText.facebook) that can be set by user in ShareIt.init() function. Default string for each network's button match the previously hard-coded strings.
