### PR TITLE
'location' gives wrong adresses on production with mupx and spiderable

### DIFF
--- a/client/views/facebook/facebook.coffee
+++ b/client/views/facebook/facebook.coffee
@@ -12,10 +12,10 @@ Template.shareit_facebook.onRendered ->
     # OpenGraph tags
     #
     $('<meta>', { property: 'og:type', content: 'article' }).appendTo 'head'
-    $('<meta>', { property: 'og:site_name', content: location.hostname }).appendTo 'head'
+    $('<meta>', { property: 'og:site_name', content: ShareIt.location.hostname() }).appendTo 'head'
 
     url = data.facebook?.url || data.url
-    url = if _.isString(url) and url.length then url else location.href
+    url = if _.isString(url) and url.length then url else ShareIt.location.href()
     $('<meta>', { property: 'og:url', content: url }).appendTo 'head'
 
     title = data.facebook?.title || data.title
@@ -46,7 +46,7 @@ Template.shareit_facebook.onRendered ->
       img = if _.isFunction data.thumbnail then data.thumbnail() else data.thumbnail
 
       if _.isString(img) and img.length
-        img = location.origin + img unless /^http(s?):\/\/+/.test(img)
+        img = ShareIt.location.origin() + img unless /^http(s?):\/\/+/.test(img)
         $('<meta>', { property: 'og:image', content: img }).appendTo 'head'
       else
         img = ''

--- a/client/views/googleplus/googleplus.coffee
+++ b/client/views/googleplus/googleplus.coffee
@@ -10,11 +10,11 @@ Template.shareit_googleplus.onRendered ->
     # Schema tags
     #
     description = data.googleplus?.description || data.excerpt || data.description || data.summary
-    url = data.url || location.origin + location.pathname
+    url = data.url || Shareit.location.origin() + Shareit.location.pathname()
     title = data.title
     itemtype = data.googleplus?.itemtype || 'Article'
     $('html').attr('itemscope', '').attr('itemtype', "http://schema.org/#{itemtype}")
-    $('<meta>', { itemprop: 'name', content: location.hostname }).appendTo 'head'
+    $('<meta>', { itemprop: 'name', content: Shareit.location.hostname() }).appendTo 'head'
     $('<meta>', { itemprop: 'url', content: url }).appendTo 'head'
     $('<meta>', { itemprop: 'description', content: description }).appendTo 'head'
 
@@ -25,7 +25,7 @@ Template.shareit_googleplus.onRendered ->
         img = data.thumbnail
     if img
       if not /^http(s?):\/\/+/.test(img)
-        img = location.origin + img
+        img = Shareit.location.origin() + img
 
     $('<meta>', { itemprop: 'image', content: img }).appendTo 'head'
     #

--- a/client/views/googleplus/googleplus.coffee
+++ b/client/views/googleplus/googleplus.coffee
@@ -10,11 +10,11 @@ Template.shareit_googleplus.onRendered ->
     # Schema tags
     #
     description = data.googleplus?.description || data.excerpt || data.description || data.summary
-    url = data.url || Shareit.location.origin() + Shareit.location.pathname()
+    url = data.url || ShareIt.location.origin() + ShareIt.location.pathname()
     title = data.title
     itemtype = data.googleplus?.itemtype || 'Article'
     $('html').attr('itemscope', '').attr('itemtype', "http://schema.org/#{itemtype}")
-    $('<meta>', { itemprop: 'name', content: Shareit.location.hostname() }).appendTo 'head'
+    $('<meta>', { itemprop: 'name', content: ShareIt.location.hostname() }).appendTo 'head'
     $('<meta>', { itemprop: 'url', content: url }).appendTo 'head'
     $('<meta>', { itemprop: 'description', content: description }).appendTo 'head'
 
@@ -25,7 +25,7 @@ Template.shareit_googleplus.onRendered ->
         img = data.thumbnail
     if img
       if not /^http(s?):\/\/+/.test(img)
-        img = Shareit.location.origin() + img
+        img = ShareIt.location.origin() + img
 
     $('<meta>', { itemprop: 'image', content: img }).appendTo 'head'
     #

--- a/client/views/pinterest/pinterest.coffee
+++ b/client/views/pinterest/pinterest.coffee
@@ -5,7 +5,7 @@ Template.shareit_pinterest.onRendered ->
     template = Template.instance()
     data = Template.currentData()
 
-    preferred_url = data.url || location.origin + location.pathname
+    preferred_url = data.url || ShareIt.location.origin() + ShareIt.location.pathname()
     url = encodeURIComponent preferred_url
     description = encodeURIComponent data.pinterest?.description || data.description
 

--- a/client/views/twitter/twitter.coffee
+++ b/client/views/twitter/twitter.coffee
@@ -13,7 +13,7 @@ Template.shareit_twitter.onRendered ->
     #$('<meta>', { property: 'twitter:site', content: '' }).appendTo 'head'
 
     url = data.twitter?.url || data.url
-    url = if _.isString(url) and url.length then url else location.origin + location.pathname
+    url = if _.isString(url) and url.length then url else ShareIt.location.origin() + ShareIt.location.pathname()
     $('<meta>', { property: 'twitter:url', content: url }).appendTo 'head'
 
     author = data.twitter?.author || data.author
@@ -37,7 +37,7 @@ Template.shareit_twitter.onRendered ->
     if data.thumbnail?
       img = if _.isFunction data.thumbnail then data.thumbnail() else data.thumbnail  
       if _.isString(img) and img.length
-        img = location.origin + img unless /^http(s?):\/\/+/.test(img)          
+        img = ShareIt.location.origin() + img unless /^http(s?):\/\/+/.test(img)          
         $('<meta>', { property: 'twitter:image', content: img }).appendTo 'head'
       else
         img = ''

--- a/shareit.coffee
+++ b/shareit.coffee
@@ -9,6 +9,18 @@ script_loader = (url, id, d = document) ->
 
 
 ShareIt =
+  # plain location is wrong on spiderable.
+  location:
+    host: Meteor.bindEnvironment () ->
+      Meteor.absoluteUrl().replace(/^http:\/\/|^https:\/\//, '').replace(/\/$/, '')
+    href: Meteor.bindEnvironment () -> 
+      Meteor.absoluteUrl().replace(/\/$/, '') + location.pathname
+    origin: Meteor.bindEnvironment () -> 
+      Meteor.absoluteUrl().replace(/\/$/, '')
+    pathname: Meteor.bindEnvironment () -> 
+      location.pathname # "/showcontent/awjdaf2384" whatever the server location
+    hostname: Meteor.bindEnvironment () -> 
+      Meteor.absoluteUrl().replace(/^http:\/\/|^https:\/\//, '').replace(/\/$/, '')
   settings:
     autoInit: true
     buttons: 'responsive'


### PR DESCRIPTION
Using Meteor.absoluteUrl(), and some regex tricks to get the good format, was i believe the way to go ;)

Nothing was working on production spiderable with mupx, got meta:url localhost:27000 or stuff like this.
